### PR TITLE
SRE-4202 Make repos internal

### DIFF
--- a/github.go
+++ b/github.go
@@ -90,6 +90,23 @@ func updateRepoTopics(gh *github.Client, githubOrg string, ghRepo *github.Reposi
 	}
 }
 
+func updateCustomProperties(gh *github.Client, githubOrg string, ghRepo *github.Repository, dryRun bool, projectName string) {
+	customProps := []*github.CustomPropertyValue{
+		{
+			PropertyName: "bitbucket",
+			Value:        "true",
+		},
+		{
+			PropertyName: "project",
+			Value:        cleanTopic(projectName),
+		},
+	}
+	if dryRun {
+		return
+	}
+	gh.Repositories.CreateOrUpdateCustomProperties(context.Background(), githubOrg, *ghRepo.Name, customProps)
+}
+
 func updateRepo(gh *github.Client, githubOrg string, ghRepo *github.Repository, dryRun bool) {
 	if dryRun {
 		fmt.Println("Mock updating repo default branch")

--- a/github.go
+++ b/github.go
@@ -19,9 +19,15 @@ func cleanTopic(input string) string {
 }
 
 func createRepo(gh *github.Client, repo *bitbucket.Repository, config settings) *github.Repository {
+	var visibility string
+	if repo.Is_private {
+		visibility = config.visibility
+	} else {
+		visibility = "public"
+	}
 	ghRepo := &github.Repository{
 		Name:          github.Ptr(repo.Slug),
-		Private:       github.Ptr(repo.Is_private),
+		Visibility:    github.Ptr(visibility),
 		Description:   github.Ptr(repo.Description),
 		DefaultBranch: github.Ptr(repo.Mainbranch.Name),
 		Language:      github.Ptr(repo.Language),

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ type settings struct {
 	dryRun              bool
 	overwrite           bool
 	visibility          string
+	runProgram          string
 	repoFile            string
 	migrateRepoContents bool
 	migrateRepoSettings bool
@@ -44,6 +45,7 @@ func main() {
 		dryRun:              getEnvVarAsBool("GITHUB_DRYRUN"),
 		overwrite:           getEnvVarAsBool("GITHUB_OVERWRITE"),
 		visibility:          os.Getenv("GITHUB_PRIVATE_VISIBILITY"),
+		runProgram:          os.Getenv("GITHUB_RUN_PROGRAM"),
 		repoFile:            os.Getenv("REPO_FILE"),
 		migrateRepoContents: getEnvVarAsBool("MIGRATE_REPO_CONTENTS"),
 		migrateRepoSettings: getEnvVarAsBool("MIGRATE_REPO_SETTINGS"),
@@ -137,7 +139,7 @@ func migrateRepo(gh *github.Client, bb *bitbucket.Client, repoName string, confi
 	fmt.Println("Migrating to Github")
 	ghRepo := createRepo(gh, bbRepo, config)
 	if config.migrateRepoContents {
-		pushRepoToGithub(config.ghOrg, repoFolder, *ghRepo.Name, config.dryRun)
+		pushRepoToGithub(repoFolder, repoName, config)
 	} else {
 		fmt.Println("Skipping repo contents")
 	}

--- a/main.go
+++ b/main.go
@@ -146,6 +146,7 @@ func migrateRepo(gh *github.Client, bb *bitbucket.Client, repoName string, confi
 	if config.migrateRepoSettings {
 		updateRepo(gh, config.ghOrg, ghRepo, config.dryRun)
 		updateRepoTopics(gh, config.ghOrg, ghRepo, config.dryRun)
+		updateCustomProperties(gh, config.ghOrg, ghRepo, config.dryRun, bbRepo.Project.Name)
 	} else {
 		fmt.Println("Skipping repo settings")
 	}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type settings struct {
 	ghToken             string
 	dryRun              bool
 	overwrite           bool
+	visibility          string
 	repoFile            string
 	migrateRepoContents bool
 	migrateRepoSettings bool
@@ -42,6 +43,7 @@ func main() {
 		ghToken:             os.Getenv("GITHUB_TOKEN"),
 		dryRun:              getEnvVarAsBool("GITHUB_DRYRUN"),
 		overwrite:           getEnvVarAsBool("GITHUB_OVERWRITE"),
+		visibility:          os.Getenv("GITHUB_PRIVATE_VISIBILITY"),
 		repoFile:            os.Getenv("REPO_FILE"),
 		migrateRepoContents: getEnvVarAsBool("MIGRATE_REPO_CONTENTS"),
 		migrateRepoSettings: getEnvVarAsBool("MIGRATE_REPO_SETTINGS"),

--- a/main.go
+++ b/main.go
@@ -44,8 +44,8 @@ func main() {
 		ghToken:             os.Getenv("GITHUB_TOKEN"),
 		dryRun:              getEnvVarAsBool("GITHUB_DRYRUN"),
 		overwrite:           getEnvVarAsBool("GITHUB_OVERWRITE"),
-		visibility:          os.Getenv("GITHUB_PRIVATE_VISIBILITY"),
-		runProgram:          os.Getenv("GITHUB_RUN_PROGRAM"),
+		visibility:          getEnvOrDefault("GITHUB_PRIVATE_VISIBILITY", "internal"),
+		runProgram:          getEnvOrDefault("GITHUB_RUN_PROGRAM", "noop"),
 		repoFile:            os.Getenv("REPO_FILE"),
 		migrateRepoContents: getEnvVarAsBool("MIGRATE_REPO_CONTENTS"),
 		migrateRepoSettings: getEnvVarAsBool("MIGRATE_REPO_SETTINGS"),
@@ -69,6 +69,16 @@ func main() {
 	githubClient := github.NewClient(nil).WithAuthToken(config.ghToken)
 
 	migrateRepos(githubClient, bitbucketClient, repos, config)
+}
+
+// returns defaultVal if envVar is not present or empty
+func getEnvOrDefault(envVar string, defaultVal string) string {
+	result := os.Getenv(envVar)
+	if result == "" {
+		return defaultVal
+	} else {
+		return result
+	}
 }
 
 func getEnvVarAsBool(envVar string) bool {

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # BTG
-A program for migrating from Bitbucket to Github
+A program for migrating repos from a Bitbucket Cloud workspace to a Github organization
 
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ GITHUB_DRYRUN=true
 GITHUB_PRIVATE_VISIBILITY=internal
 # runs the program before git push to github
 # passes the full path to the current repo as an argument
-GITHUB_RUN_PROGRAM=/Users/calebparks/misc/gobtg/scripts/removeBigObjects.sh
+GITHUB_RUN_PROGRAM=noop
 
 MIGRATE_REPO_CONTENTS=true
 # it's suggested to migrate repo settings if you migrate repo contents

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,9 @@ GITHUB_TOKEN=CENSORED
 # whether overwriting existing github repo is allowed
 GITHUB_OVERWRITE=false
 GITHUB_DRYRUN=true
+# if the bitbucket repo is private this visibility setting will be chosen
+# it can be either private or internal
+GITHUB_PRIVATE_VISIBILITY=internal
 
 MIGRATE_REPO_CONTENTS=true
 # it's suggested to migrate repo settings if you migrate repo contents

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ GITHUB_DRYRUN=true
 # if the bitbucket repo is private this visibility setting will be chosen
 # it can be either private or internal
 GITHUB_PRIVATE_VISIBILITY=internal
+# runs the program before git push to github
+# passes the full path to the current repo as an argument
+GITHUB_RUN_PROGRAM=/Users/calebparks/misc/gobtg/scripts/removeBigObjects.sh
 
 MIGRATE_REPO_CONTENTS=true
 # it's suggested to migrate repo settings if you migrate repo contents
@@ -52,3 +55,12 @@ If you get an error when pushing your git repo it is recommended to increase you
 `git config --global http.postBuffer 957286400`
 
 Credit to the tip from [this stackoverflow](https://stackoverflow.com/a/69891948)
+
+---
+
+If you get an error pushing because a file is more than 100MB, and you want to get rid of the file, you can use the GITHUB_RUN_PROGRAM argument. For example:
+```
+GITHUB_RUN_PROGRAM=/full/path/to/gobtg/scripts/removeBigObjects.sh
+```
+
+The `removeBigObjects.sh` is a script in this repo that removes any file more than 100MB. Read the script before running.

--- a/scripts/removeBigObjects.sh
+++ b/scripts/removeBigObjects.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# thanks to https://stackoverflow.com/a/17890278
+# download BFG repo cleaner and put it at ~/Downloads/bfg.jar for this to work
+set -euo pipefail
+java -jar ~/Downloads/bfg.jar --strip-blobs-bigger-than 100M "$1"
+git reflog expire --expire=now --all
+git gc --prune=now --aggressive


### PR DESCRIPTION
* repos should be internal by default, as that is the desired default for our org.
* I also added a run program attribute for running BFG repo cleaner. This solves the issue we had with the tf-prod repo where someone accidentally included a very large file.
* I added custom properties for project and bitbucket. This could be useful to target a set of repos with rulesets. @chriswilker-ispot FYI

[SRE-4202]

[SRE-4202]: https://ispottv.atlassian.net/browse/SRE-4202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ