### PR TITLE
Cleanup codebase

### DIFF
--- a/bitbucket.go
+++ b/bitbucket.go
@@ -22,8 +22,7 @@ func getRepo(bb *bitbucket.Client, owner string, repoName string) *bitbucket.Rep
 	}
 	repo, err := bb.Repositories.Repository.Get(ro)
 	if err != nil {
-		fmt.Println("Failed to get repo from bitbucket")
-		panic(err)
+		log.Fatalf("Failed to get repo from bitbucket: %v", err)
 	}
 	return repo
 }
@@ -63,11 +62,11 @@ func updatePermissionsToReadOnly(bb *bitbucket.Client, owner string, repoName st
 	}
 	user_perms, err := bb.Repositories.Repository.ListUserPermissions(ro)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to get user permissions: %v", err)
 	}
 	group_perms, err := bb.Repositories.Repository.ListGroupPermissions(ro)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to get group permissions: %v", err)
 	}
 
 	if dryRun {
@@ -115,11 +114,11 @@ func getPrs(bb *bitbucket.Client, owner string, repo string, destinationBranch s
 	fmt.Println("getting prs for", repo)
 	response, err := bb.Repositories.PullRequests.Gets(opt)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Failed to get PRs: %v", err)
 	}
 	prs, err := decodePullRequests(response)
 	if err != nil {
-		panic(fmt.Sprintf("error decoding PRs: %s", err))
+		log.Fatalf("Error decoding PRs: %v", err)
 	}
 	slices.SortFunc(prs.Values, func(i PullRequest, j PullRequest) int {
 		return cmp.Compare(i.ID, j.ID)

--- a/github.go
+++ b/github.go
@@ -42,7 +42,6 @@ func createRepo(gh *github.Client, repo *bitbucket.Repository, config settings) 
 	}
 
 	fmt.Printf("Creating repo %s/%s\n", config.ghOwner, repo.Slug)
-	repoCreated := false
 	_, _, err := gh.Repositories.Create(context.Background(), config.ghOrg, ghRepo)
 	if err != nil {
 		if strings.Contains(err.Error(), "name already exists on this account") {
@@ -52,10 +51,6 @@ func createRepo(gh *github.Client, repo *bitbucket.Repository, config settings) 
 		} else {
 			log.Fatalf("failed to create repo %s, error: %s", repo.Slug, err)
 		}
-	}
-
-	if repoCreated {
-		return ghRepo
 	}
 
 	// The repository might not have been created yet

--- a/github.go
+++ b/github.go
@@ -160,11 +160,9 @@ func migrateOpenPrs(gh *github.Client, githubOwner string, ghRepo *github.Reposi
 			} else {
 				log.Fatalf("failed to create PR %s, error: %s", strconv.Itoa(pr.ID), err)
 			}
-			// sleep for .5s to help avoid github rate limit
-			time.Sleep(time.Millisecond * 500)
-			continue
+		} else {
+			fmt.Printf("Migrated BB PR %s as GH PR %s\n", prID, strconv.Itoa(*newPr.Number))
 		}
-		fmt.Printf("Migrated BB PR %s as GH PR %s\n", prID, strconv.Itoa(*newPr.Number))
 
 		// sleep for .5s to help avoid github rate limit
 		time.Sleep(time.Millisecond * 500)

--- a/github.go
+++ b/github.go
@@ -164,8 +164,7 @@ func migrateOpenPrs(gh *github.Client, githubOwner string, ghRepo *github.Reposi
 			fmt.Printf("Migrated BB PR %s as GH PR %s\n", prID, strconv.Itoa(*newPr.Number))
 		}
 
-		// sleep for .5s to help avoid github rate limit
-		time.Sleep(time.Millisecond * 500)
+		time.Sleep(GitHubRateLimitSleep)
 	}
 }
 
@@ -217,8 +216,8 @@ func createClosedPrs(gh *github.Client, githubOwner string, ghRepo *github.Repos
 		if err != nil {
 			log.Fatalf("failed to close issue %s: %s", *issueResponse.URL, err)
 		}
-		// sleep for .5s to help avoid github rate limit
-		time.Sleep(time.Millisecond * 500)
+
+		time.Sleep(GitHubRateLimitSleep)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,11 @@ import (
 	"github.com/ktrysmt/go-bitbucket"
 )
 
+const (
+	// we want to avoid hitting API rate limits
+	GitHubRateLimitSleep = 500 * time.Millisecond
+)
+
 type settings struct {
 	bbWorkspace         string
 	bbUsername          string
@@ -198,6 +203,5 @@ func migrateRepo(gh *github.Client, bb *bitbucket.Client, repoName string, confi
 	fmt.Println("done migrating repo")
 	fmt.Print("-----------------------\n\n")
 
-	// sleep for .5s to help avoid github rate limit
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(GitHubRateLimitSleep)
 }


### PR DESCRIPTION
I did some cleanup of the codebase to make it more professional

* standardize error handling ~ I had some cases where I used `panic` and other cases where I used `log.Fatalf`. I standardized on `log.Fatalf`.
* remove useless `repoCreated` variable
* Refactor API rate limit to shared constant so there's no duplicate code
* Instead of manually converting integer to string with `strconv.Itoa`, rely on `%d` format specifier to do it for me. Makes the code shorter & simpler.